### PR TITLE
Replace '+' with '%20' in signature parameters

### DIFF
--- a/transip/client.py
+++ b/transip/client.py
@@ -81,7 +81,7 @@ class Client(object):
         sign['__timestamp'] = timestamp
         sign['__nonce'] = nonce
 
-        return urllib.urlencode(sign).replace('%5B', '[').replace('%5D', ']')
+        return urllib.urlencode(sign).replace('%5B', '[').replace('%5D', ']').replace('+', '%20')
 
     def update_cookie(self, cookies):
         """ Updates the cookie for the upcoming call to the API. """


### PR DESCRIPTION
It is not uncommon to use spaces in DNS entry content. The current signing implementation will never produce a valid TransIP signature when this occurs.
The use of [PHP's `rawurlencode()`](http://php.net/manual/en/function.rawurlencode.php) in the [TransIP sources](https://api.transip.nl/docs/transip.nl/source-class-Transip_DomainService.html#192) results in spaces being replaced by `%20`. [Python's `urllib.urlencode()`](https://docs.python.org/2/library/urllib.html#urllib.urlencode) will produce `+` characters instead.

The fix will create a valid signature. Existing `+` characters in a value should not cause a problem because they will already be replaced by `urllib.urlencode()`.