### PR TITLE
Fix order_vps method in VpsService

### DIFF
--- a/transip/service/vps.py
+++ b/transip/service/vps.py
@@ -45,13 +45,26 @@ class VpsService(Client):
         self.update_cookie(cookie)
         return self.soap_client.service.getCancellableAddonsForVps(vps_name)
 
-    # This function gives a signature error.
-    # def order_vps(self, product_name, addons, operating_system_name, hostname):
-    #     """ Order a VPS with optional Addons """
-    #     cookie = self.build_cookie(mode=MODE_RW, method='orderVps', \
-    #         parameters=[product_name, addons, operating_system_name, hostname])
-    #     self.update_cookie(cookie)
-    #     return self.soap_client.service.orderVps(product_name, addons, operating_system_name, hostname)
+    def order_vps(self, product_name, addons, operating_system_name, hostname):
+        """ Order a VPS with optional Addons """
+        if not addons:
+            # An empty list of Addons gives a signature error due to the Addons
+            # not being added to the OrderedDict in
+            # transip.client.Client._build_signature_message.
+            addons = None
+        else:
+            # A list of Addons (or an empty list) gives a signature error due
+            # to the Addons not being added to the OrderedDict in
+            # transip.client.Client._build_signature_message.
+            # The _build_signature_message method only adds list items if
+            # they are an instance of SudsObject.
+            raise NotImplementedError('Addons paramenter not implemented. Use '
+                                      'the order_addon method instead.')
+
+        cookie = self.build_cookie(mode=MODE_RW, method='orderVps', \
+            parameters=[product_name, addons, operating_system_name, hostname])
+        self.update_cookie(cookie)
+        return self.soap_client.service.orderVps(product_name, addons, operating_system_name, hostname)
 
     def clone_vps(self, vps_name):
         """ Clone a VPS """


### PR DESCRIPTION
Partially fix the `order_vps` method is VpsService. It's now possible to order a Vps without addons. If addons are specified anyway, an `NotImplementedError` will be raised.

The signature error was caused by the addons not being added to the `OrderedDict` in `transip.client.Client._build_signature_message`. The `_build_signature_message` method only adds list items if they are an instance of `SudsObject`.

This MR has been tested by manually ordering a number of vps.

Example usage:

```python
from transip.service.vps import VpsService


client = VpsService('accountname')

# The order_vps method succeeds when no addons are specified:
client.order_vps('vps-bladevps-x1', None, 'ubuntu-18.04', 'hostname')
client.order_vps('vps-bladevps-x1', [], 'ubuntu-18.04', 'hostname')

# The order_vps will raise a NotImplementedError when addons are specified:
client.order_vps('vps-bladevps-x1', ['nonexisting'], 'ubuntu-18.04', 'hostname')
```

