### PR TITLE
Change PyCrypto to cryptography

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Prerequisite
 * Whitelist your IP.
 * Generate a new key-pair.
 	+ Copy-paste the private key into a file.
-	+ Either reformat the key to PKCS#1 format using ``$ openssl rsa -in input.key -out decrypted_key`` or install PyCrypto using ``$ pip install pycrypto``.
+	+ Either reformat the key to PKCS#1 format using ``$ openssl rsa -in input.key -out decrypted_key`` or install cryptography using ``$ pip install cryptography``.
 	+ Put the private key in a file called ``decrypted_key`` beside this ``README.rst`` file.
 
 Setup


### PR DESCRIPTION
Change PyCryto to cryptography because the PyCrypto library isn't updated in the last couple of years and has a known vulnerability.

The cryptography library is able to read the private key file in both PKCS and OpenSSH format.

See:
- [pycrypto#253](https://github.com/dlitz/pycrypto/issues/253)
- [TElgamal/attack-on-pycrypto-elgamal](https://github.com/TElgamal/attack-on-pycrypto-elgamal)
- [pycrypto#275](https://github.com/dlitz/pycrypto/issues/275)
- [pycrypto#158](https://github.com/dlitz/pycrypto/issues/158)