### PR TITLE
Add option to specify the private key directly

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Here is an example of a simple Python program:
    -----END PRIVATE KEY-----
    '''
 
-   # You can specify the private key directly of supply the path to the private
+   # You can specify the private key directly or supply the path to the private
    # key file. The private_key_file will default to `decrypted_key`.
    client = VpsService('accountname', private_key_file='/path/to/decrypted_key')
    client = VpsService('accountname', private_key=PRIVATE_KEY)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,16 @@ Here is an example of a simple Python program:
    from transip.service.vps import VpsService
 
 
-   client = VpsService('accountname')
+   PRIVATE_KEY = '''
+   -----BEGIN PRIVATE KEY-----
+   ...
+   -----END PRIVATE KEY-----
+   '''
+
+   # You can specify the private key directly of supply the path to the private
+   # key file. The private_key_file will default to `decrypted_key`.
+   client = VpsService('accountname', private_key_file='/path/to/decrypted_key')
+   client = VpsService('accountname', private_key=PRIVATE_KEY)
 
    # Order a Vps without addons:
    client.order_vps('vps-bladevps-x1', None, 'ubuntu-18.04', 'vps-name')


### PR DESCRIPTION
Add option to specify the private key directly and updated the
docstring. This commit also updates the example in the documentation
(`docs/index.rst`). This still defaults to the `private_key_file` as the default.