### PR TITLE
Automated PyPi deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,16 @@ install:
 script: 
  - nosetests --rednose --with-coverage --cover-package=transip
  - pylint --rcfile=.pylintrc transip
+
+# Deploy a new release to PyPi for every new tag on the 'master' branch on the
+# repository 'benkonrath/transip-api'.
+deploy:
+  provider: pypi
+  user: roaldnefs
+  password:
+    secure: "ej8lf26roItqLNrfsLxFVNWjLVipoVo62wNGsobj2x3AcuzqVRreHw3pTapmDXjNf9/fpsDLHx14ljI7k+WfUNwB51depqwleWG5cEZyNMP1A365a/j7QfGiE/aiS/Nmi0A6U7eiovku9PiBY0TL3JqU/Mx6w9dA0C9yCRkxIKg="
+  on:
+    repo: benkonrath/transip-api
+    tags: true
+    branch: master
+    python: 3.6


### PR DESCRIPTION
Add Travis configuration for automated PyPi deployments for tagged commits on the 'master' branch on 'benkonrath/transip-api'.

For more information see: https://docs.travis-ci.com/user/deployment/pypi/

This requires the PyPi credentials of a maintainer of [transip](https://pypi.org/project/transip/)! Please note that I am not a maintainer on PyPi, so the credentials will not work.