### PR TITLE
Update the library name in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,11 @@ Prerequisite
 Setup
 -----
 
+You can get the library directly from PyPi:
+
 .. code-block::
 
-	$ python setup.py install
-
+    $ pip install transip
 
 Example
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,9 +24,9 @@ Here is an example of a simple Python program:
    # Order a Vps without addons:
    client.order_vps('vps-bladevps-x1', None, 'ubuntu-18.04', 'vps-name')
 
-You can get the library directly from PyPI::
+You can get the library directly from PyPi::
 
-   pip install transip-api
+   pip install transip
 
 Documentation
 -------------


### PR DESCRIPTION
Update the library name in the documentation:
- Change `transip-api` to `transip` in `docs/index.rst`.
- Add `pip install transip` to `README.rst`.