### PR TITLE
Fix --api-key CLI argument

### DIFF
--- a/transip/transip_cli.py
+++ b/transip/transip_cli.py
@@ -99,7 +99,7 @@ def main():
     if not args.api_key_file:
         args.api_key_file = 'decrypted_key'
 
-    domain_service = DomainService(args.loginname, args.api_key_file)
+    domain_service = DomainService(args.loginname, private_key_file=args.api_key_file)
 
     if args.add_dns_entry or args.update_dns_entry or args.delete_dns_entry:
         if [args.add_dns_entry, args.update_dns_entry, args.delete_dns_entry].count(True) > 1:


### PR DESCRIPTION
Adding the option to specify the private key directly in Client broke the --api-key CLI argument. The value of --api-key was passed to the argument private_key instead of private_key_file.

Fixed by passing the value of --api-key as a keyword argument to DomainService.