### PR TITLE
Fix invalid wsdl

### DIFF
--- a/transip/client.py
+++ b/transip/client.py
@@ -66,7 +66,7 @@ class SudsFilter(DocumentPlugin):
         Replaces an invalid type in the wsdl document with a validy type.
         """
         document = context.document
-        context.document = document.decode().replace('xsd:array', 'tns:ArrayOfstring')
+        context.document = document.decode().replace('xsd:array', 'tns:ArrayOfstring').encode()
 
 class Client(object):
     """

--- a/transip/client.py
+++ b/transip/client.py
@@ -56,7 +56,7 @@ def convert_value(value):
 class SudsFilter(DocumentPlugin):
     def loaded(self, context):
         document = context.document
-        context.document = document.replace('xsd:array', 'tns:ArrayOfstring')
+        context.document = document.replace('xsd:array', 'tns:ArrayOfstring').encode()
 
 class Client(object):
     """

--- a/transip/client.py
+++ b/transip/client.py
@@ -80,8 +80,9 @@ class Client(object):
         self.endpoint = endpoint
         self.url = URI_TEMPLATE.format(endpoint, service_name)
 
-        imp = Import('http://schemas.xmlsoap.org/soap/encoding/')
-        doc = ImportDoctor(imp)
+        imp_soap = Import('http://schemas.xmlsoap.org/soap/encoding/')
+        imp_w3 = Import('http://www.w3.org/2001/XMLSchema')
+        doc = ImportDoctor(imp_soap, imp_w3)
 
         suds_kwargs = dict()
         if suds_requests:

--- a/transip/client.py
+++ b/transip/client.py
@@ -53,20 +53,18 @@ def convert_value(value):
 
     return value
 
-class SudsFilter(DocumentPlugin):
+class WSDLFixPlugin(DocumentPlugin):
+    # pylint: disable=W0232
     """
     A SudsFilter to fix wsdl document before it is parsed.
     """
-    def __init__(self):
-        pass
 
     def loaded(self, context):
         # pylint: disable=R0201
         """
         Replaces an invalid type in the wsdl document with a validy type.
         """
-        document = context.document
-        context.document = document.decode().replace('xsd:array', 'tns:ArrayOfstring').encode()
+        context.document = context.document.replace(b'xsd:array', b'soapenc:Array')
 
 class Client(object):
     """
@@ -102,7 +100,7 @@ class Client(object):
         if suds_requests:
             suds_kwargs['transport'] = suds_requests.RequestsTransport()
 
-        self.soap_client = SudsClient(self.url, doctor=doc, plugins=[SudsFilter()], **suds_kwargs)
+        self.soap_client = SudsClient(self.url, doctor=doc, plugins=[WSDLFixPlugin()], **suds_kwargs)
 
     def _sign(self, message):
         """ Uses the decrypted private key to sign the message. """

--- a/transip/client.py
+++ b/transip/client.py
@@ -54,9 +54,19 @@ def convert_value(value):
     return value
 
 class SudsFilter(DocumentPlugin):
+    """
+    A SudsFilter to fix wsdl document before it is parsed.
+    """
+    def __init__(self):
+        pass
+
     def loaded(self, context):
+        # pylint: disable=R0201
+        """
+        Replaces an invalid type in the wsdl document with a validy type.
+        """
         document = context.document
-        context.document = document.replace('xsd:array', 'tns:ArrayOfstring').encode()
+        context.document = document.decode().replace('xsd:array', 'tns:ArrayOfstring')
 
 class Client(object):
     """

--- a/transip/client.py
+++ b/transip/client.py
@@ -53,6 +53,10 @@ def convert_value(value):
 
     return value
 
+class SudsFilter(DocumentPlugin):
+    def loaded(self, context):
+        document = context.document
+        context.document = document.replace('xsd:array', 'tns:ArrayOfstring')
 
 class Client(object):
     """
@@ -89,12 +93,6 @@ class Client(object):
             suds_kwargs['transport'] = suds_requests.RequestsTransport()
 
         self.soap_client = SudsClient(self.url, doctor=doc, plugins=[SudsFilter()], **suds_kwargs)
-
-    class SudsFilter(DocumentPlugin):
-        def loaded(self, context):
-            print context
-            document = context.document
-            context.document = document.replace('xsd:array', 'tns:ArrayOfstring')
 
     def _sign(self, message):
         """ Uses the decrypted private key to sign the message. """


### PR DESCRIPTION
This is a fix for #60 

The wsdl contains a type (`xsd:array`) that is not present in xsd (www.w3.org/2001/XMLSchema), which is why the wsdl is invalid.
This fix uses the suds DocumentPlugin to patch the wsdl before parsing the document.

I'm not sure whether this is the best way to fix a faulty wsdl, but hopefully it's a step in the right direction.